### PR TITLE
Fix maven publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,3 +111,11 @@ signing {
     required = true
 }
 */
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}


### PR DESCRIPTION
Currently any gradle publishing commands are a no-op, this will allow you to install/publish to repositories.