### PR TITLE
Add nmsPrefix switch to PackageVersion, add 1.18 support

### DIFF
--- a/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
+++ b/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
@@ -81,7 +81,7 @@ public enum PackageVersion {
     private final @NonNull String obcPrefix;
 
     PackageVersion() {
-       this(false);
+        this(false);
     }
 
     PackageVersion(boolean useModern) {

--- a/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
+++ b/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
@@ -84,8 +84,8 @@ public enum PackageVersion {
        this(false);
     }
 
-    PackageVersion(boolean useModern){
-        this.nmsPrefix = useModern?NMS_MODERN:NMS + getPackageComponent();
+    PackageVersion(boolean useModern) {
+        this.nmsPrefix = (useModern ? NMS_MODERN : NMS) + getPackageComponent();
         this.obcPrefix = OBC + getPackageComponent();
     }
 

--- a/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
+++ b/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
@@ -59,12 +59,18 @@ public enum PackageVersion {
     v1_16_R1,
     v1_16_R2,
     v1_16_R3,
-    v1_17_R1;
+    v1_17_R1(true),
+    v1_18_R1(true);
 
     /**
      * The nms prefix (without the version component)
      */
     public static final String NMS = "net.minecraft.server";
+
+    /**
+     * The nms prefix for 1.17+ (excludes version component)
+     */
+    public static final String NMS_MODERN = "net.minecraft.";
 
     /**
      * The obc prefix (without the version component)
@@ -75,7 +81,11 @@ public enum PackageVersion {
     private final @NonNull String obcPrefix;
 
     PackageVersion() {
-        this.nmsPrefix = NMS + getPackageComponent();
+       this(false);
+    }
+
+    PackageVersion(boolean useModern){
+        this.nmsPrefix = useModern?NMS_MODERN:NMS + getPackageComponent();
         this.obcPrefix = OBC + getPackageComponent();
     }
 


### PR DESCRIPTION
This PR adds a flag to PackageVersion enums for using the "modern" style of NMS packaging. This is necessary for clean reflection into NMS classes like the Session service and such.