### PR TITLE
Fix incorrect nmsPrefix for useModern versioning

### DIFF
--- a/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
+++ b/src/main/java/me/lucko/shadow/bukkit/PackageVersion.java
@@ -85,7 +85,7 @@ public enum PackageVersion {
     }
 
     PackageVersion(boolean useModern) {
-        this.nmsPrefix = (useModern ? NMS_MODERN : NMS) + getPackageComponent();
+        this.nmsPrefix = useModern ? NMS_MODERN : (NMS + getPackageComponent());
         this.obcPrefix = OBC + getPackageComponent();
     }
 


### PR DESCRIPTION
Also removes the packageComponent from nmsPrefix for modern versions because "net.minecraft..v1_18_r1.world.entity.Entity" isn't a valid class.

I'm unsure how I didn't catch this before submitting the last PR, nor how this was even close to remotely working during my testing originally. 